### PR TITLE
Add support for multiple integrations

### DIFF
--- a/pkg/client/run.go
+++ b/pkg/client/run.go
@@ -18,37 +18,53 @@ package client
 
 import (
 	"log"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/bitnami-labs/kubewatch/config"
-	"github.com/bitnami-labs/kubewatch/pkg/handlers"
-	"github.com/bitnami-labs/kubewatch/pkg/handlers/slack"
 	"github.com/bitnami-labs/kubewatch/pkg/controller"
+	"github.com/bitnami-labs/kubewatch/pkg/handlers"
+	"github.com/bitnami-labs/kubewatch/pkg/handlers/flock"
 	"github.com/bitnami-labs/kubewatch/pkg/handlers/hipchat"
 	"github.com/bitnami-labs/kubewatch/pkg/handlers/mattermost"
-	"github.com/bitnami-labs/kubewatch/pkg/handlers/flock"
+	"github.com/bitnami-labs/kubewatch/pkg/handlers/slack"
 	"github.com/bitnami-labs/kubewatch/pkg/handlers/webhook"
 )
 
 // Run runs the event loop processing with given handler
 func Run(conf *config.Config) {
-	var eventHandler handlers.Handler
-	switch {
-	case len(conf.Handler.Slack.Channel) > 0 || len(conf.Handler.Slack.Token) > 0:
-		eventHandler = new(slack.Slack)
-	case len(conf.Handler.Hipchat.Room) > 0 || len(conf.Handler.Hipchat.Token) > 0:
-		eventHandler = new(hipchat.Hipchat)
-	case len(conf.Handler.Mattermost.Channel) > 0 || len(conf.Handler.Mattermost.Url) > 0:
-		eventHandler = new(mattermost.Mattermost)
-	case len(conf.Handler.Flock.Url) > 0:
-		eventHandler = new(flock.Flock)
-	case len(conf.Handler.Webhook.Url) > 0:
-		eventHandler = new(webhook.Webhook)
-	default:
-		eventHandler = new(handlers.Default)
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	var eventHandler []handlers.Handler
+	if len(conf.Handler.Slack.Channel) > 0 || len(conf.Handler.Slack.Token) > 0 {
+		eventHandler = append(eventHandler, new(slack.Slack))
+	}
+	if len(conf.Handler.Hipchat.Room) > 0 || len(conf.Handler.Hipchat.Token) > 0 {
+		eventHandler = append(eventHandler, new(hipchat.Hipchat))
+	}
+	if len(conf.Handler.Mattermost.Channel) > 0 || len(conf.Handler.Mattermost.Url) > 0 {
+		eventHandler = append(eventHandler, new(mattermost.Mattermost))
+	}
+	if len(conf.Handler.Flock.Url) > 0 {
+		eventHandler = append(eventHandler, new(flock.Flock))
+	}
+	if len(conf.Handler.Webhook.Url) > 0 {
+		eventHandler = append(eventHandler, new(webhook.Webhook))
 	}
 
-	if err := eventHandler.Init(conf); err != nil {
-		log.Fatal(err)
+	if len(eventHandler) == 0 {
+		eventHandler = append(eventHandler, new(handlers.Default))
 	}
-	controller.Start(conf, eventHandler)
+
+	log.Printf("%v\n", eventHandler)
+	for _, handler := range eventHandler {
+		controller.Start(conf, handler, stopCh)
+	}
+
+	sigterm := make(chan os.Signal, 1)
+	signal.Notify(sigterm, syscall.SIGTERM)
+	signal.Notify(sigterm, syscall.SIGINT)
+	<-sigterm
 }


### PR DESCRIPTION
Now, each event integration makes use of its own event
listerer and notifies the associated channel on events.

Fixes #150

Signed-off-by: Amarnath <vaamarnath@gmail.com>