### PR TITLE
Granular and Extended Event Alerting

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,54 @@ You may also provide a values file instead:
 rbac:
   create: true
 resourcesToWatch:
-  daemonset: true
-  deployment: false
-  pod: true
-  replicaset: false
-  replicationcontroller: false
-  services: true
-  secret: false
-  configmap: false
+  daemonset:
+   watch: true
+   events:
+    create: true
+    update: true
+    delete: false
+  deployment:
+   watch: true
+   events: 
+    create: true
+    update: true
+    delete: false
+  pod:
+   watch: true
+   events: 
+    create: true
+    update: true
+    delete: true
+  replicaset:
+   watch: true
+   events: 
+    create: true
+    update: true
+    delete: false
+  replicationcontroller:
+   watch: true
+   events: 
+    create: true
+    update: true
+    delete: false
+  services:
+   watch: true
+   events: 
+    create: true
+    update: true
+    delete: false
+  secret:
+   watch: true
+   events: 
+    create: true
+    update: true
+    delete: false
+  configmap:
+   watch: true
+   events: 
+    create: true
+    update: true
+    delete: false
 slack:
   channel: '#YOUR_CHANNEL'
   token: 'xoxb-YOUR_TOKEN'
@@ -73,15 +113,60 @@ To modify what notifications you get, update the `kubewatch` ConfigMap and turn 
 
 ```
 resource:
-      deployment: false
-      replicationcontroller: false
-      replicaset: false
-      daemonset: false
-      services: true
-      pod: true
-      secret: false
-      configmap: false
-      ingress: false
+      deployment:
+       watch: true
+       events: 
+        create: true
+        update: true
+        delete: false
+      replicationcontroller:
+       watch: true
+       events: 
+        create: true
+        update: true
+        delete: false
+      replicaset:
+       watch: true
+       events: 
+        create: true
+        update: true
+        delete: true
+      daemonset:
+       watch: true
+       events: 
+        create: true
+        update: true
+        delete: false
+      services:
+       watch: true
+       events: 
+        create: true
+        update: true
+        delete: false
+      pod:
+       watch: true
+       events: 
+        create: true
+        update: true
+        delete: false
+      secret:
+       watch: true
+       events: 
+        create: true
+        update: true
+        delete: false
+      configmap:
+       watch: true
+       events: 
+        create: true
+        update: true
+        delete: false
+      ingress:
+       watch: true
+       events: 
+        create: true
+        update: true
+        delete: false
 ```
 
 ### Working with RBAC

--- a/cmd/resource.go
+++ b/cmd/resource.go
@@ -36,84 +36,120 @@ var resourceConfigCmd = &cobra.Command{
 		var b bool
 		b, err = cmd.Flags().GetBool("svc")
 		if err == nil {
-			conf.Resource.Services = b
+			conf.Resource.Services.Watch = b
+			conf.Resource.Services.Events.Create = b
+			conf.Resource.Services.Events.Update = b
+			conf.Resource.Services.Events.Delete = b
 		} else {
 			logrus.Fatal("svc", err)
 		}
 
 		b, err = cmd.Flags().GetBool("deployments")
 		if err == nil {
-			conf.Resource.Deployment = b
+			conf.Resource.Deployment.Watch = b
+			conf.Resource.Deployment.Events.Create = b
+			conf.Resource.Deployment.Events.Update = b
+			conf.Resource.Deployment.Events.Delete = b
 		} else {
 			logrus.Fatal("deployments", err)
 		}
 
 		b, err = cmd.Flags().GetBool("po")
 		if err == nil {
-			conf.Resource.Pod = b
+			conf.Resource.Pod.Watch = b
+			conf.Resource.Pod.Events.Create = b
+			conf.Resource.Pod.Events.Update = b
+			conf.Resource.Pod.Events.Delete = b
 		} else {
 			logrus.Fatal("po", err)
 		}
 
 		b, err = cmd.Flags().GetBool("rs")
 		if err == nil {
-			conf.Resource.ReplicaSet = b
+			conf.Resource.ReplicaSet.Watch = b
+			conf.Resource.ReplicaSet.Events.Create = b
+			conf.Resource.ReplicaSet.Events.Update = b
+			conf.Resource.ReplicaSet.Events.Delete = b
 		} else {
 			logrus.Fatal("rs", err)
 		}
 
 		b, err = cmd.Flags().GetBool("rc")
 		if err == nil {
-			conf.Resource.ReplicationController = b
+			conf.Resource.ReplicationController.Watch = b
+			conf.Resource.ReplicationController.Events.Create = b
+			conf.Resource.ReplicationController.Events.Update = b
+			conf.Resource.ReplicationController.Events.Delete = b
 		} else {
 			logrus.Fatal("rc", err)
 		}
 
 		b, err = cmd.Flags().GetBool("ns")
 		if err == nil {
-			conf.Resource.Namespace = b
+			conf.Resource.Namespace.Watch = b
+			conf.Resource.Namespace.Events.Create = b
+			conf.Resource.Namespace.Events.Update = b
+			conf.Resource.Namespace.Events.Delete = b
 		} else {
 			logrus.Fatal("ns", err)
 		}
 
 		b, err = cmd.Flags().GetBool("jobs")
 		if err == nil {
-			conf.Resource.Job = b
+			conf.Resource.Job.Watch = b
+			conf.Resource.Job.Events.Create = b
+			conf.Resource.Job.Events.Update = b
+			conf.Resource.Job.Events.Delete = b
 		} else {
 			logrus.Fatal("jobs", err)
 		}
 
 		b, err = cmd.Flags().GetBool("pv")
 		if err == nil {
-			conf.Resource.PersistentVolume = b
+			conf.Resource.PersistentVolume.Watch = b
+			conf.Resource.PersistentVolume.Events.Create = b
+			conf.Resource.PersistentVolume.Events.Update = b
+			conf.Resource.PersistentVolume.Events.Delete = b
 		} else {
 			logrus.Fatal("pv", err)
 		}
 
 		b, err = cmd.Flags().GetBool("ds")
 		if err == nil {
-			conf.Resource.DaemonSet = b
+			conf.Resource.DaemonSet.Watch = b
+			conf.Resource.DaemonSet.Events.Create = b
+			conf.Resource.DaemonSet.Events.Update = b
+			conf.Resource.DaemonSet.Events.Delete = b
 		} else {
 			logrus.Fatal("ds", err)
 		}
 
 		b, err = cmd.Flags().GetBool("secret")
 		if err == nil {
-			conf.Resource.Secret = b
+			conf.Resource.Secret.Watch = b
+			conf.Resource.Secret.Events.Create = b
+			conf.Resource.Secret.Events.Update = b
+			conf.Resource.Secret.Events.Delete = b
 		} else {
 			logrus.Fatal("secret", err)
 		}
 
 		b, err = cmd.Flags().GetBool("configmap")
 		if err == nil {
-			conf.Resource.ConfigMap = b
+			conf.Resource.ConfigMap.Watch = b
+			conf.Resource.ConfigMap.Events.Create = b
+			conf.Resource.ConfigMap.Events.Update = b
+			conf.Resource.ConfigMap.Events.Delete = b
 		} else {
 			logrus.Fatal("configmap", err)
 		}
 
 		b, err = cmd.Flags().GetBool("ing")
 		if err == nil {
-			conf.Resource.Ingress = b
+			conf.Resource.Ingress.Watch = b
+			conf.Resource.Ingress.Events.Create = b
+			conf.Resource.Ingress.Events.Update = b
+			conf.Resource.Ingress.Events.Delete = b
 		} else {
 			logrus.Fatal("ing", err)
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -37,18 +37,30 @@ type Handler struct {
 
 // Resource contains resource configuration
 type Resource struct {
-	Deployment            bool `json:"deployment"`
-	ReplicationController bool `json:"rc"`
-	ReplicaSet            bool `json:"rs"`
-	DaemonSet             bool `json:"ds"`
-	Services              bool `json:"svc"`
-	Pod                   bool `json:"po"`
-	Job                   bool `json:"job"`
-	PersistentVolume      bool `json:"pv"`
-	Namespace             bool `json:"ns"`
-	Secret                bool `json:"secret"`
-	ConfigMap             bool `json:"configmap"`
-	Ingress               bool `json:"ing"`
+	Deployment            WatchType `json:"deployment"`
+	ReplicationController WatchType `json:"rc"`
+	ReplicaSet            WatchType `json:"rs"`
+	DaemonSet             WatchType `json:"ds"`
+	Services              WatchType `json:"svc"`
+	Pod                   WatchType `json:"po"`
+	Job                   WatchType `json:"job"`
+	PersistentVolume      WatchType `json:"pv"`
+	Namespace             WatchType `json:"ns"`
+	Secret                WatchType `json:"secret"`
+	ConfigMap             WatchType `json:"configmap"`
+	Ingress               WatchType `json:"ing"`
+}
+
+type WatchType struct {
+	Watch  bool      `json:"watch"`
+	Events EventType `json:"events"`
+}
+
+type EventType struct {
+	Create             bool `json:"create"`
+	Update             bool `json:"update"`
+	Delete             bool `json:"delete"`
+	LoadBalancerCreate bool `json:"loadbalancercreate"`
 }
 
 // Config struct contains kubewatch configuration
@@ -144,41 +156,77 @@ func (c *Config) Load() error {
 }
 
 func (c *Config) CheckMissingResourceEnvvars() {
-	if !c.Resource.DaemonSet && os.Getenv("KW_DAEMONSET") == "true" {
-		c.Resource.DaemonSet = true
+	if !c.Resource.DaemonSet.Watch && os.Getenv("KW_DAEMONSET") == "true" {
+		c.Resource.DaemonSet.Watch = true
+		c.Resource.DaemonSet.Events.Create = true
+		c.Resource.DaemonSet.Events.Update = true
+		c.Resource.DaemonSet.Events.Delete = true
 	}
-	if !c.Resource.ReplicaSet && os.Getenv("KW_REPLICASET") == "true" {
-		c.Resource.ReplicaSet = true
+	if !c.Resource.ReplicaSet.Watch && os.Getenv("KW_REPLICASET") == "true" {
+		c.Resource.ReplicaSet.Watch = true
+		c.Resource.ReplicaSet.Events.Create = true
+		c.Resource.ReplicaSet.Events.Update = true
+		c.Resource.ReplicaSet.Events.Delete = true
 	}
-	if !c.Resource.Namespace && os.Getenv("KW_NAMESPACE") == "true" {
-		c.Resource.Namespace = true
+	if !c.Resource.Namespace.Watch && os.Getenv("KW_NAMESPACE") == "true" {
+		c.Resource.Namespace.Watch = true
+		c.Resource.Namespace.Events.Create = true
+		c.Resource.Namespace.Events.Update = true
+		c.Resource.Namespace.Events.Delete = true
 	}
-	if !c.Resource.Deployment && os.Getenv("KW_DEPLOYMENT") == "true" {
-		c.Resource.Deployment = true
+	if !c.Resource.Deployment.Watch && os.Getenv("KW_DEPLOYMENT") == "true" {
+		c.Resource.Deployment.Watch = true
+		c.Resource.Deployment.Events.Create = true
+		c.Resource.Deployment.Events.Update = true
+		c.Resource.Deployment.Events.Delete = true
 	}
-	if !c.Resource.Pod && os.Getenv("KW_POD") == "true" {
-		c.Resource.Pod = true
+	if !c.Resource.Pod.Watch && os.Getenv("KW_POD") == "true" {
+		c.Resource.Pod.Watch = true
+		c.Resource.Pod.Events.Create = true
+		c.Resource.Pod.Events.Update = true
+		c.Resource.Pod.Events.Delete = true
 	}
-	if !c.Resource.ReplicationController && os.Getenv("KW_REPLICATION_CONTROLLER") == "true" {
-		c.Resource.ReplicationController = true
+	if !c.Resource.ReplicationController.Watch && os.Getenv("KW_REPLICATION_CONTROLLER") == "true" {
+		c.Resource.ReplicationController.Watch = true
+		c.Resource.ReplicationController.Events.Create = true
+		c.Resource.ReplicationController.Events.Update = true
+		c.Resource.ReplicationController.Events.Delete = true
 	}
-	if !c.Resource.Services && os.Getenv("KW_SERVICE") == "true" {
-		c.Resource.Services = true
+	if !c.Resource.Services.Watch && os.Getenv("KW_SERVICE") == "true" {
+		c.Resource.Services.Watch = true
+		c.Resource.Services.Events.Create = true
+		c.Resource.Services.Events.Update = true
+		c.Resource.Services.Events.Delete = true
 	}
-	if !c.Resource.Job && os.Getenv("KW_JOB") == "true" {
-		c.Resource.Job = true
+	if !c.Resource.Job.Watch && os.Getenv("KW_JOB") == "true" {
+		c.Resource.Job.Watch = true
+		c.Resource.Job.Events.Create = true
+		c.Resource.Job.Events.Update = true
+		c.Resource.Job.Events.Delete = true
 	}
-	if !c.Resource.PersistentVolume && os.Getenv("KW_PERSISTENT_VOLUME") == "true" {
-		c.Resource.PersistentVolume = true
+	if !c.Resource.PersistentVolume.Watch && os.Getenv("KW_PERSISTENT_VOLUME") == "true" {
+		c.Resource.PersistentVolume.Watch = true
+		c.Resource.PersistentVolume.Events.Create = true
+		c.Resource.PersistentVolume.Events.Update = true
+		c.Resource.PersistentVolume.Events.Delete = true
 	}
-	if !c.Resource.Secret && os.Getenv("KW_SECRET") == "true" {
-		c.Resource.Secret = true
+	if !c.Resource.Secret.Watch && os.Getenv("KW_SECRET") == "true" {
+		c.Resource.Secret.Watch = true
+		c.Resource.Secret.Events.Create = true
+		c.Resource.Secret.Events.Update = true
+		c.Resource.Secret.Events.Delete = true
 	}
-	if !c.Resource.ConfigMap && os.Getenv("KW_CONFIGMAP") == "true" {
-		c.Resource.ConfigMap = true
+	if !c.Resource.ConfigMap.Watch && os.Getenv("KW_CONFIGMAP") == "true" {
+		c.Resource.ConfigMap.Watch = true
+		c.Resource.ConfigMap.Events.Create = true
+		c.Resource.ConfigMap.Events.Update = true
+		c.Resource.ConfigMap.Events.Delete = true
 	}
-	if !c.Resource.Ingress && os.Getenv("KW_INGRESS") == "true" {
-		c.Resource.Ingress = true
+	if !c.Resource.Ingress.Watch && os.Getenv("KW_INGRESS") == "true" {
+		c.Resource.Ingress.Watch = true
+		c.Resource.Ingress.Events.Create = true
+		c.Resource.Ingress.Events.Update = true
+		c.Resource.Ingress.Events.Delete = true
 	}
 	if (c.Handler.Slack.Channel == "") && (os.Getenv("SLACK_CHANNEL") != "") {
 		c.Handler.Slack.Channel = os.Getenv("SLACK_CHANNEL")

--- a/kubewatch-configmap.yaml
+++ b/kubewatch-configmap.yaml
@@ -10,11 +10,39 @@ data:
         token: <token>
         channel: <channel>
     resource:
-      deployment: false
-      replicationcontroller: false
-      replicaset: false
-      daemonset: false
-      services: true
-      pod: true
-      secret: false
-      configmap: false
+      deployment:
+       watch: true
+       events:
+        create: true
+        update: false
+        delete: true
+      replicationcontroller:
+       watch: true
+       events:
+        create: true
+      replicaset:
+       watch: true
+       events:
+        create: true
+      daemonset:
+       watch: true
+       events:
+        create: true
+      services:
+       watch: true
+       events:
+        create: true
+        update: true
+        loadbalancercreate: true
+      pod:
+       watch: true
+       events:
+        create: true
+      secret:
+       watch: true
+       events:
+        create: true
+      configmap:
+       watch: true
+       events:
+        create: true

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -54,6 +54,7 @@ type Event struct {
 	eventType    string
 	namespace    string
 	resourceType string
+	Message      string
 }
 
 // Controller object
@@ -73,7 +74,7 @@ func Start(conf *config.Config, eventHandler handlers.Handler) {
 	} else {
 		kubeClient = utils.GetClient()
 	}
-	if conf.Resource.Pod {
+	if conf.Resource.Pod.Watch {
 		informer := cache.NewSharedIndexInformer(
 			&cache.ListWatch{
 				ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
@@ -88,14 +89,14 @@ func Start(conf *config.Config, eventHandler handlers.Handler) {
 			cache.Indexers{},
 		)
 
-		c := newResourceController(kubeClient, eventHandler, informer, "pod")
+		c := newResourceController(kubeClient, eventHandler, informer, "pod", conf.Resource.Pod.Events)
 		stopCh := make(chan struct{})
 		defer close(stopCh)
 
 		go c.Run(stopCh)
 	}
 
-	if conf.Resource.DaemonSet {
+	if conf.Resource.DaemonSet.Watch {
 		informer := cache.NewSharedIndexInformer(
 			&cache.ListWatch{
 				ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
@@ -110,14 +111,14 @@ func Start(conf *config.Config, eventHandler handlers.Handler) {
 			cache.Indexers{},
 		)
 
-		c := newResourceController(kubeClient, eventHandler, informer, "daemonset")
+		c := newResourceController(kubeClient, eventHandler, informer, "daemonset", conf.Resource.DaemonSet.Events)
 		stopCh := make(chan struct{})
 		defer close(stopCh)
 
 		go c.Run(stopCh)
 	}
 
-	if conf.Resource.ReplicaSet {
+	if conf.Resource.ReplicaSet.Watch {
 		informer := cache.NewSharedIndexInformer(
 			&cache.ListWatch{
 				ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
@@ -132,14 +133,14 @@ func Start(conf *config.Config, eventHandler handlers.Handler) {
 			cache.Indexers{},
 		)
 
-		c := newResourceController(kubeClient, eventHandler, informer, "replicaset")
+		c := newResourceController(kubeClient, eventHandler, informer, "replicaset", conf.Resource.ReplicaSet.Events)
 		stopCh := make(chan struct{})
 		defer close(stopCh)
 
 		go c.Run(stopCh)
 	}
 
-	if conf.Resource.Services {
+	if conf.Resource.Services.Watch {
 		informer := cache.NewSharedIndexInformer(
 			&cache.ListWatch{
 				ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
@@ -154,14 +155,14 @@ func Start(conf *config.Config, eventHandler handlers.Handler) {
 			cache.Indexers{},
 		)
 
-		c := newResourceController(kubeClient, eventHandler, informer, "service")
+		c := newResourceController(kubeClient, eventHandler, informer, "service", conf.Resource.Services.Events)
 		stopCh := make(chan struct{})
 		defer close(stopCh)
 
 		go c.Run(stopCh)
 	}
 
-	if conf.Resource.Deployment {
+	if conf.Resource.Deployment.Watch {
 		informer := cache.NewSharedIndexInformer(
 			&cache.ListWatch{
 				ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
@@ -176,14 +177,14 @@ func Start(conf *config.Config, eventHandler handlers.Handler) {
 			cache.Indexers{},
 		)
 
-		c := newResourceController(kubeClient, eventHandler, informer, "deployment")
+		c := newResourceController(kubeClient, eventHandler, informer, "deployment", conf.Resource.Deployment.Events)
 		stopCh := make(chan struct{})
 		defer close(stopCh)
 
 		go c.Run(stopCh)
 	}
 
-	if conf.Resource.Namespace {
+	if conf.Resource.Namespace.Watch {
 		informer := cache.NewSharedIndexInformer(
 			&cache.ListWatch{
 				ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
@@ -198,14 +199,14 @@ func Start(conf *config.Config, eventHandler handlers.Handler) {
 			cache.Indexers{},
 		)
 
-		c := newResourceController(kubeClient, eventHandler, informer, "namespace")
+		c := newResourceController(kubeClient, eventHandler, informer, "namespace", conf.Resource.Namespace.Events)
 		stopCh := make(chan struct{})
 		defer close(stopCh)
 
 		go c.Run(stopCh)
 	}
 
-	if conf.Resource.ReplicationController {
+	if conf.Resource.ReplicationController.Watch {
 		informer := cache.NewSharedIndexInformer(
 			&cache.ListWatch{
 				ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
@@ -220,14 +221,14 @@ func Start(conf *config.Config, eventHandler handlers.Handler) {
 			cache.Indexers{},
 		)
 
-		c := newResourceController(kubeClient, eventHandler, informer, "replication controller")
+		c := newResourceController(kubeClient, eventHandler, informer, "replication controller", conf.Resource.ReplicationController.Events)
 		stopCh := make(chan struct{})
 		defer close(stopCh)
 
 		go c.Run(stopCh)
 	}
 
-	if conf.Resource.Job {
+	if conf.Resource.Job.Watch {
 		informer := cache.NewSharedIndexInformer(
 			&cache.ListWatch{
 				ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
@@ -242,14 +243,14 @@ func Start(conf *config.Config, eventHandler handlers.Handler) {
 			cache.Indexers{},
 		)
 
-		c := newResourceController(kubeClient, eventHandler, informer, "job")
+		c := newResourceController(kubeClient, eventHandler, informer, "job", conf.Resource.Job.Events)
 		stopCh := make(chan struct{})
 		defer close(stopCh)
 
 		go c.Run(stopCh)
 	}
 
-	if conf.Resource.PersistentVolume {
+	if conf.Resource.PersistentVolume.Watch {
 		informer := cache.NewSharedIndexInformer(
 			&cache.ListWatch{
 				ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
@@ -264,14 +265,14 @@ func Start(conf *config.Config, eventHandler handlers.Handler) {
 			cache.Indexers{},
 		)
 
-		c := newResourceController(kubeClient, eventHandler, informer, "persistent volume")
+		c := newResourceController(kubeClient, eventHandler, informer, "persistent volume", conf.Resource.PersistentVolume.Events)
 		stopCh := make(chan struct{})
 		defer close(stopCh)
 
 		go c.Run(stopCh)
 	}
 
-	if conf.Resource.Secret {
+	if conf.Resource.Secret.Watch {
 		informer := cache.NewSharedIndexInformer(
 			&cache.ListWatch{
 				ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
@@ -286,14 +287,14 @@ func Start(conf *config.Config, eventHandler handlers.Handler) {
 			cache.Indexers{},
 		)
 
-		c := newResourceController(kubeClient, eventHandler, informer, "secret")
+		c := newResourceController(kubeClient, eventHandler, informer, "secret", conf.Resource.Secret.Events)
 		stopCh := make(chan struct{})
 		defer close(stopCh)
 
 		go c.Run(stopCh)
 	}
 
-	if conf.Resource.ConfigMap {
+	if conf.Resource.ConfigMap.Watch {
 		informer := cache.NewSharedIndexInformer(
 			&cache.ListWatch{
 				ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
@@ -308,14 +309,14 @@ func Start(conf *config.Config, eventHandler handlers.Handler) {
 			cache.Indexers{},
 		)
 
-		c := newResourceController(kubeClient, eventHandler, informer, "configmap")
+		c := newResourceController(kubeClient, eventHandler, informer, "configmap", conf.Resource.ConfigMap.Events)
 		stopCh := make(chan struct{})
 		defer close(stopCh)
 
 		go c.Run(stopCh)
 	}
 
-	if conf.Resource.Ingress {
+	if conf.Resource.Ingress.Watch {
 		informer := cache.NewSharedIndexInformer(
 			&cache.ListWatch{
 				ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
@@ -330,7 +331,7 @@ func Start(conf *config.Config, eventHandler handlers.Handler) {
 			cache.Indexers{},
 		)
 
-		c := newResourceController(kubeClient, eventHandler, informer, "ingress")
+		c := newResourceController(kubeClient, eventHandler, informer, "ingress", conf.Resource.Ingress.Events)
 		stopCh := make(chan struct{})
 		defer close(stopCh)
 
@@ -343,37 +344,44 @@ func Start(conf *config.Config, eventHandler handlers.Handler) {
 	<-sigterm
 }
 
-func newResourceController(client kubernetes.Interface, eventHandler handlers.Handler, informer cache.SharedIndexInformer, resourceType string) *Controller {
+func newResourceController(client kubernetes.Interface, eventHandler handlers.Handler, informer cache.SharedIndexInformer, resourceType string, eventType config.EventType) *Controller {
 	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 	var newEvent Event
 	var err error
 	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			newEvent.key, err = cache.MetaNamespaceKeyFunc(obj)
-			newEvent.eventType = "create"
-			newEvent.resourceType = resourceType
-			logrus.WithField("pkg", "kubewatch-"+resourceType).Infof("Processing add to %v: %s", resourceType, newEvent.key)
-			if err == nil {
-				queue.Add(newEvent)
+			if eventType.Create {
+				newEvent.key, err = cache.MetaNamespaceKeyFunc(obj)
+				newEvent.eventType = "create"
+				newEvent.resourceType = resourceType
+				logrus.WithField("pkg", "kubewatch-"+resourceType).Infof("Processing add to %v: %s", resourceType, newEvent.key)
+				if err == nil {
+					queue.Add(newEvent)
+				}
 			}
 		},
 		UpdateFunc: func(old, new interface{}) {
-			newEvent.key, err = cache.MetaNamespaceKeyFunc(old)
-			newEvent.eventType = "update"
-			newEvent.resourceType = resourceType
-			logrus.WithField("pkg", "kubewatch-"+resourceType).Infof("Processing update to %v: %s", resourceType, newEvent.key)
-			if err == nil {
-				queue.Add(newEvent)
+			if eventType.Update {
+				newEvent.key, err = cache.MetaNamespaceKeyFunc(old)
+				newEvent.eventType = "update"
+				newEvent.resourceType = resourceType
+				logrus.WithField("pkg", "kubewatch-"+resourceType).Infof("Processing update to %v: %s", resourceType, newEvent.key)
+				if err == nil {
+					queue.Add(newEvent)
+				}
+				AddExtendedEventMessage(eventType, &newEvent, old, new)
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
-			newEvent.key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
-			newEvent.eventType = "delete"
-			newEvent.resourceType = resourceType
-			newEvent.namespace = utils.GetObjectMetaData(obj).Namespace
-			logrus.WithField("pkg", "kubewatch-"+resourceType).Infof("Processing delete to %v: %s", resourceType, newEvent.key)
-			if err == nil {
-				queue.Add(newEvent)
+			if eventType.Delete {
+				newEvent.key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+				newEvent.eventType = "delete"
+				newEvent.resourceType = resourceType
+				newEvent.namespace = utils.GetObjectMetaData(obj).Namespace
+				logrus.WithField("pkg", "kubewatch-"+resourceType).Infof("Processing delete to %v: %s", resourceType, newEvent.key)
+				if err == nil {
+					queue.Add(newEvent)
+				}
 			}
 		},
 	})
@@ -384,6 +392,18 @@ func newResourceController(client kubernetes.Interface, eventHandler handlers.Ha
 		informer:     informer,
 		queue:        queue,
 		eventHandler: eventHandler,
+	}
+}
+
+func AddExtendedEventMessage(eventType config.EventType, newEvent *Event, old, new interface{}) {
+	switch old.(type) {
+	case *api_v1.Service:
+		oldobj := old.(*api_v1.Service)
+		newobj := new.(*api_v1.Service)
+		if eventType.LoadBalancerCreate && len(oldobj.Status.LoadBalancer.Ingress) < len(newobj.Status.LoadBalancer.Ingress) {
+			newEvent.Message = fmt.Sprintf("A new LoadBalancer has been created for service %s in namespace %s",
+				oldobj.Name, oldobj.Namespace)
+		}
 	}
 }
 
@@ -477,6 +497,7 @@ func (c *Controller) processItem(newEvent Event) error {
 		kbEvent := event.Event{
 			Kind: newEvent.resourceType,
 			Name: newEvent.key,
+			Msg:  newEvent.Message,
 		}
 		c.eventHandler.ObjectUpdated(obj, kbEvent)
 		return nil

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -34,6 +34,7 @@ type Event struct {
 	Reason    string
 	Status    string
 	Name      string
+	Msg       string
 }
 
 var m = map[string]string{
@@ -109,13 +110,17 @@ func (e *Event) Message() (msg string) {
 			e.Reason,
 		)
 	default:
-		msg = fmt.Sprintf(
-			"A `%s` in namespace `%s` has been `%s`:\n`%s`",
-			e.Kind,
-			e.Namespace,
-			e.Reason,
-			e.Name,
-		)
+		if e.Msg == "" {
+			msg = fmt.Sprintf(
+				"A `%s` in namespace `%s` has been `%s`:\n`%s`",
+				e.Kind,
+				e.Namespace,
+				e.Reason,
+				e.Name,
+			)
+		} else {
+			msg = e.Msg
+		}
 	}
 	return msg
 }


### PR DESCRIPTION
fixes #105

This feature adds support to alert on specific event type per resource.
For example, to watch only create and update events on deployment resource, kubewatch.yaml should be
resource:
deployment:
watch: true
events:
create: true
update: true
delete: false
This also adds custom event type 'loadbalancercreate' to notify when there is a loadbalancer created for a service.
resource:
services:
watch: true
events:
create: true
update: true
delete: true
loadbalancercreate: true